### PR TITLE
fix: add new IPs

### DIFF
--- a/api/webhook.ts
+++ b/api/webhook.ts
@@ -13,7 +13,7 @@ const WEBHOOK_AVATAR_URL = 'https://ldw.screfy.com/static/linear.png';
 
 const LINEAR_BASE_URL = 'https://linear.app';
 const LINEAR_COLOR = '#5E6AD2';
-const LINEAR_TRUSTED_IPS = z.enum(['35.231.147.226', '35.243.134.228']);
+const LINEAR_TRUSTED_IPS = z.enum(['35.231.147.226', '35.243.134.228', '34.140.253.14', '34.38.87.206']);
 
 const QUERY_SCHEMA = z.object({
 	webhookId: z.string(),


### PR DESCRIPTION
Linear now has more IPs that it sends requests with, as documented here: https://developers.linear.app/docs/graphql/webhooks